### PR TITLE
fix(repository): avoid reassign of filter on where or-clause

### DIFF
--- a/src/repositories/soft-crud.repository.base.ts
+++ b/src/repositories/soft-crud.repository.base.ts
@@ -47,17 +47,15 @@ export abstract class SoftCrudRepository<
       (filter.where as OrClause<T>).or &&
       (filter.where as OrClause<T>).or.length > 0
     ) {
-      filter = {
-        where: {
-          and: [
-            {
-              deleted: false,
-            } as Condition<T>,
-            {
-              or: (filter.where as OrClause<T>).or,
-            },
-          ],
-        },
+      filter.where = {
+        and: [
+          {
+            deleted: false,
+          } as Condition<T>,
+          {
+            or: (filter.where as OrClause<T>).or,
+          },
+        ],
       };
     } else {
       filter = filter ?? {};
@@ -87,17 +85,15 @@ export abstract class SoftCrudRepository<
       (filter.where as OrClause<T>).or &&
       (filter.where as OrClause<T>).or.length > 0
     ) {
-      filter = {
-        where: {
-          and: [
-            {
-              deleted: false,
-            } as Condition<T>,
-            {
-              or: (filter.where as OrClause<T>).or,
-            },
-          ],
-        },
+      filter.where = {
+        and: [
+          {
+            deleted: false,
+          } as Condition<T>,
+          {
+            or: (filter.where as OrClause<T>).or,
+          },
+        ],
       };
     } else {
       filter = filter ?? {};
@@ -129,27 +125,23 @@ export abstract class SoftCrudRepository<
       (filter.where as OrClause<T>).or &&
       (filter.where as OrClause<T>).or.length > 0
     ) {
-      filter = {
-        where: {
-          and: [
-            {
-              deleted: false,
-              id: id,
-            } as Condition<T>,
-            {
-              or: (filter.where as OrClause<T>).or,
-            },
-          ],
-        },
+      filter.where = {
+        and: [
+          {
+            deleted: false,
+            id: id,
+          } as Condition<T>,
+          {
+            or: (filter.where as OrClause<T>).or,
+          },
+        ],
       };
     } else {
       filter = filter ?? {};
-      filter = {
-        where: {
-          deleted: false,
-          id: id,
-        } as Condition<T>,
-      };
+      filter.where = {
+        deleted: false,
+        id: id,
+      } as Condition<T>;
     }
 
     //As parent method findById have filter: FilterExcludingWhere<T>


### PR DESCRIPTION
## Description

We found a problem in our internal application where neither Loopback's Fields filter nor Include filter where working (but only in findById query, list query was working without problems). We traced the cause to the loopback4-soft-delete extension and made this fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested ?

- [X] Running provided tests
- [X] Testing in a real application which showed the problem

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] Code conforms with the style guide
