### PR TITLE
fix(sequelize): remove default export of sequelize repository

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -3,7 +3,7 @@ sonar.sources=src
 
 # Ignoring transaction and sequelize soft crud repository as the duplication of the code is a compulsion in it.
 # These will be removed in a next major release in favor of universal mixin usage.
-sonar.exclusions=src/__tests__/**,src/repositories/default-transaction-soft-crud.repository.base.ts,src/repositories/sequelize.soft-crud.repository.base.ts
+sonar.exclusions=src/__tests__/**,src/repositories/default-transaction-soft-crud.repository.base.ts,src/repositories/sequelize/sequelize.soft-crud.repository.base.ts
 #sonar.inclusions=
 
 # Path to tests

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If not, then please add these columns to the DB table.
 ### SequelizeSoftCrudRepository
 
 An abstract base class providing soft delete capabilities for projects using [loopback4-sequelize](https://www.npmjs.com/package/loopback4-sequelize) package.
-All the other workings are similar to [SoftCrudRepository](#softcrudrepository).
+All the other workings are similar to [SoftCrudRepository](#softcrudrepository). except it's imported using directory import syntax from `loopback4-soft-delete/sequelize`.
 
 ### SoftCrudRepository
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,0 @@
-export * from './dist';

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist');

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,0 @@
-export * from './src';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loopback4-soft-delete",
-  "version": "7.1.2",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loopback4-soft-delete",
-      "version": "7.1.2",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "@loopback/core": "^4.0.8",
@@ -43,6 +43,7 @@
         "husky": "^7.0.4",
         "jsdom": "^21.0.0",
         "loopback-datasource-juggler": "^4.28.1",
+        "loopback4-sequelize": "^2.1.0",
         "minimist": ">=1.2.6",
         "semantic-release": "^19.0.3",
         "simple-git": "^3.15.1",
@@ -2053,8 +2054,7 @@
       "version": "13.7.12",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.12.tgz",
       "integrity": "sha512-YVtyAPqpefU+Mm/qqnOANW6IkqKpCSrarcyV269C8MA8Ux0dbkEuQwM/4CjL47kVEM2LgBef/ETfkH+c6+moFA==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.52.0",
@@ -4111,8 +4111,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.3.tgz",
       "integrity": "sha512-4liA0PuRkZWQFQjwBypdxPfZaRWiv5tkhMXY2hzsa2pNf5s7U3m9cwUchfNKe8wZQxdGPQQzO6Rm2uGe0rvohQ==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -6547,8 +6546,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/loopback4-sequelize/-/loopback4-sequelize-2.1.0.tgz",
       "integrity": "sha512-k6msq4mIRlKmbRD9Kabx8ZwKs+yCrHJZfxYrBizEQPXQhfWtei/RrDPWPPnSvWLx8EtWhjpenyOG5U4mQyR8cg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "sequelize": "^6.28.0",
@@ -6572,7 +6570,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -7202,8 +7200,7 @@
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7212,8 +7209,7 @@
       "version": "0.5.41",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.41.tgz",
       "integrity": "sha512-e0jGNZDOHfBXJGz8vR/sIMXvBIGJJcqFjmlg9lmE+5KX1U7/RZNMswfD8nKnNCnQdKTIj50IaRKwl1fvMLyyRg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -11212,8 +11208,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -11891,8 +11886,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
       "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -12092,7 +12086,7 @@
     },
     "node_modules/semver": {
       "version": "7.3.8",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12183,14 +12177,13 @@
       "version": "6.29.0",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.0.tgz",
       "integrity": "sha512-m8Wi90rs3NZP9coXE52c7PL4Q078nwYZXqt1IxPvgki7nOFn0p/F0eKsYDBXCPw9G8/BCEa6zZNk0DQUAT4ypA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
           "url": "https://opencollective.com/sequelize"
         }
       ],
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",
@@ -12246,8 +12239,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
       "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -12256,8 +12248,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -13133,8 +13124,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/tough-cookie": {
       "version": "4.1.2",
@@ -13823,8 +13813,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
       "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -13933,7 +13922,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,24 @@
     "loopback-extension",
     "loopback"
   ],
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./sequelize": {
+      "types": "./dist/repositories/sequelize/index.d.ts",
+      "default": "./dist/repositories/sequelize/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "sequelize": [
+        "./dist/repositories/sequelize/index.d.ts"
+      ]
+    }
+  },
   "engines": {
-    "node": ">=8.9"
+    "node": ">=14"
   },
   "scripts": {
     "build": "npm run clean && lb-tsc",
@@ -86,6 +101,7 @@
     "husky": "^7.0.4",
     "jsdom": "^21.0.0",
     "loopback-datasource-juggler": "^4.28.1",
+    "loopback4-sequelize": "^2.1.0",
     "minimist": ">=1.2.6",
     "semantic-release": "^19.0.3",
     "simple-git": "^3.15.1",

--- a/src/__tests__/unit/sequelize/sequelize-soft-crud.unit.ts
+++ b/src/__tests__/unit/sequelize/sequelize-soft-crud.unit.ts
@@ -12,7 +12,7 @@ import {fail} from 'assert';
 import {SoftDeleteEntity} from '../../../models';
 import {IUser} from '../../../types';
 import {SequelizeDataSource} from 'loopback4-sequelize';
-import {SequelizeSoftCrudRepository} from '../../../repositories/sequelize.soft-crud.repository.base';
+import {SequelizeSoftCrudRepository} from '../../../repositories/sequelize/sequelize.soft-crud.repository.base';
 
 /**
  * A mock up model class

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,3 +1,2 @@
 export * from './soft-crud.repository.base';
-export * from './sequelize.soft-crud.repository.base';
 export * from './default-transaction-soft-crud.repository.base';

--- a/src/repositories/sequelize/index.ts
+++ b/src/repositories/sequelize/index.ts
@@ -1,0 +1,1 @@
+export * from './sequelize.soft-crud.repository.base';

--- a/src/repositories/sequelize/sequelize.soft-crud.repository.base.ts
+++ b/src/repositories/sequelize/sequelize.soft-crud.repository.base.ts
@@ -16,10 +16,10 @@ import {
   SequelizeDataSource,
 } from 'loopback4-sequelize';
 
-import {ErrorKeys} from '../error-keys';
-import {SoftDeleteEntity} from '../models';
-import {IUser} from '../types';
-import {SoftFilterBuilder} from '../utils/soft-filter-builder';
+import {ErrorKeys} from '../../error-keys';
+import {SoftDeleteEntity} from '../../models';
+import {IUser} from '../../types';
+import {SoftFilterBuilder} from '../../utils/soft-filter-builder';
 
 export abstract class SequelizeSoftCrudRepository<
   E extends SoftDeleteEntity,


### PR DESCRIPTION
## Description

- Add directory import syntax when using sequelize
- Remove default export of sequelize repository from repositories/index.ts 

GH-135
Fixes #135 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested ?

- [x] Tested in few services of microservices catalog using npm pack, it's working fine without installing the sequelize package.
- [x] Tested in a freshly created lb4 app https://github.com/shubhamp-sf/loopback4-soft-delete-example-with-sequelize

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
