### PR TITLE
fix(repository): remove imposing behaviour of fields

### DIFF
--- a/src/repositories/soft-crud.repository.base.ts
+++ b/src/repositories/soft-crud.repository.base.ts
@@ -10,7 +10,6 @@ import {
   Filter,
   juggler,
   Where,
-  Fields,
   Condition,
 } from '@loopback/repository';
 import {Count} from '@loopback/repository/src/common-types';
@@ -43,7 +42,6 @@ export abstract class SoftCrudRepository<
       .imposeCondition({
         deleted: false,
       } as Condition<E>)
-      .fields(filter?.fields ? (['deleted'] as Fields<E>) : [])
       .build();
 
     return super.find(modifiedFilter, options);
@@ -58,7 +56,6 @@ export abstract class SoftCrudRepository<
       .imposeCondition({
         deleted: false,
       } as Condition<E>)
-      .fields(filter?.fields ? (['deleted'] as Fields<E>) : [])
       .build();
 
     return super.findOne(modifiedFilter, options);
@@ -85,14 +82,13 @@ export abstract class SoftCrudRepository<
         deleted: false,
         [idProp]: id,
       } as Condition<E>)
-      .fields(originalFilter.fields ? (['deleted'] as Fields<E>) : [])
+      .limit(1)
       .build();
 
-    const entity = await super.findById(id, modifiedFilter, options);
+    const entity = await super.find(modifiedFilter, options);
 
-    if (entity && !entity.deleted) {
-      this.removeColumnIfNotRequested(entity, originalFilter);
-      return entity;
+    if (entity && entity.length > 0) {
+      return entity[0];
     } else {
       throw new HttpErrors.NotFound(ErrorKeys.EntityNotFound);
     }
@@ -209,36 +205,5 @@ export abstract class SoftCrudRepository<
     }
     const userId = currentUser.getIdentifier?.() ?? currentUser.id;
     return userId?.toString();
-  }
-  /**
-   * Strip out columns from entity if not requested in originalFilter
-   * @param entity Data to modify
-   * @param originalFilter Original Filter definition to validate keys with
-   */
-  private removeColumnIfNotRequested(
-    entity: E,
-    originalFilter: Filter<E>,
-    columnsToRemove: Extract<keyof SoftDeleteEntity, string>[] = ['deleted'],
-  ) {
-    if (!originalFilter.fields) {
-      return;
-    }
-    if (Array.isArray(originalFilter.fields)) {
-      const fields = originalFilter.fields as Extract<
-        keyof SoftDeleteEntity,
-        string
-      >[];
-      for (const col of columnsToRemove) {
-        if (!fields.includes(col)) {
-          delete entity[col];
-        }
-      }
-    } else {
-      for (const col of columnsToRemove) {
-        if (!originalFilter.fields[col]) {
-          delete entity[col];
-        }
-      }
-    }
   }
 }

--- a/src/utils/soft-filter-builder.ts
+++ b/src/utils/soft-filter-builder.ts
@@ -1,7 +1,6 @@
 import {
   AndClause,
   Condition,
-  Fields,
   Filter,
   FilterBuilder,
   OrClause,
@@ -15,7 +14,6 @@ import {SoftDeleteEntity} from '../models';
  * ```ts
  * const filterBuilder = new SoftFilterBuilder(originalFilter)
  *    .imposeCondition({ deleted: false })
- *    .fields(["deleted"])
  *    .build();
  * ```
  */
@@ -24,6 +22,13 @@ export class SoftFilterBuilder<E extends SoftDeleteEntity> {
 
   constructor(originalFilter?: Filter<E>) {
     this.filter = originalFilter ?? {};
+  }
+
+  limit(limit: number) {
+    this.filter.limit = new FilterBuilder(this.filter)
+      .limit(limit)
+      .build().limit;
+    return this;
   }
 
   imposeCondition(conditionToEnsure: Condition<E>) {
@@ -49,13 +54,6 @@ export class SoftFilterBuilder<E extends SoftDeleteEntity> {
     if (!(hasAndClause && hasOrClause)) {
       Object.assign(this.filter.where, conditionToEnsure);
     }
-    return this;
-  }
-
-  fields(...f: (Fields<E> | Extract<keyof E, string>)[]) {
-    this.filter.fields = new FilterBuilder(this.filter)
-      .fields(...f)
-      .build().fields;
     return this;
   }
 


### PR DESCRIPTION
## Description

- Removed the mandatory addition of `deleted` column in fields filter
- Replaced `super.findById` call with `super.find` as findById doesn't respect where filter and explicit conditions were used to check if entity is deleted or not.

GH-142
Fixes #142 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested ?

- [x] Tested in an internal application
- [x] Tested in a fresh lb4 app https://github.com/shubhamp-sf/loopback4-soft-delete-example

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [x] API Documentation in code was updated
