### PR TITLE
feat(repository): implement undo soft delete feature

### DIFF
--- a/src/repositories/soft-crud.repository.base.ts
+++ b/src/repositories/soft-crud.repository.base.ts
@@ -4,13 +4,13 @@
 
 import {Getter} from '@loopback/core';
 import {
+  Condition,
   DataObject,
   DefaultCrudRepository,
   Entity,
   Filter,
-  juggler,
   Where,
-  Condition,
+  juggler,
 } from '@loopback/repository';
 import {Count} from '@loopback/repository/src/common-types';
 import {HttpErrors} from '@loopback/rest';
@@ -164,6 +164,33 @@ export abstract class SoftCrudRepository<
         deletedOn: new Date(),
         deletedBy,
       },
+      options,
+    );
+  }
+
+  /**
+   * Method to perform undo the soft delete by Id.
+   * @param id
+   * @param options
+   */
+  async undoSoftDeleteById(id: ID, options?: Options): Promise<void> {
+    await this.undoSoftDeleteAll({id} as Where<E>, options);
+  }
+
+  /**
+   * Method to perform undo all the soft deletes
+   * @param where
+   * @param options
+   */
+  async undoSoftDeleteAll(where?: Where<E>, options?: Options): Promise<Count> {
+    const filter = new SoftFilterBuilder({where})
+      .imposeCondition({
+        deleted: true,
+      } as Condition<E>)
+      .build();
+    return super.updateAll(
+      {deleted: false, deletedOn: undefined},
+      filter.where,
       options,
     );
   }


### PR DESCRIPTION
GH-182

## Description

Add 2 functionalities to undo the soft delete of a record
1. undoSoftDeleteById() -> This will just undo soft delete entity by specified id
2. undoSoftDeleteAll() -> This will undo soft delete entities depending on where clause or all.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested ?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [x] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
